### PR TITLE
feat: adapt sw64. sw64 ruby3.0 has no shlibs.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -97,3 +97,6 @@ override_dh_gencontrol:
 override_dh_makeshlibs:
 	dh_makeshlibs -plibselinux1 --add-udeb="libselinux1-udeb" -V
 	dh_makeshlibs --remaining-packages
+
+override_dh_shlibdeps:
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info


### PR DESCRIPTION
      适配sw64.