### PR TITLE
feat:  adapt sw64. debian/ruls dpkg-shlibdeps-params=--ignore-missing…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+libselinux (3.5-1deepin4) unstable; urgency=medium
+
+  * feat: adapt sw64. debian/ruls dpkg-shlibdeps-params=--ignore-missing-info.
+  *       sw64 ruby3.0 has no shlibs.
+  *       适配sw64.
+
+ -- zhangya <zhangya@uniontech.com>  Wed, 19 Feb 2025 15:01:08 +0800
+
 libselinux (3.5-1deepin3) unstable; urgency=medium
 
   * Separartion of SELinux and USEC configuration.

--- a/debian/rules
+++ b/debian/rules
@@ -97,3 +97,6 @@ override_dh_gencontrol:
 override_dh_makeshlibs:
 	dh_makeshlibs -plibselinux1 --add-udeb="libselinux1-udeb" -V
 	dh_makeshlibs --remaining-packages
+
+override_dh_shlibdeps:
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info


### PR DESCRIPTION
…-info.

       sw64 ruby3.0 has no shlibs.
       适配sw64.